### PR TITLE
ci: configure cache for yarn and node_modules

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,6 +5,11 @@ language: node_js
 node_js:
   - "node"
 
+cache:
+  yarn: true
+  directories:
+    - node_modules
+
 before_install:
   - curl -o- -L https://yarnpkg.com/install.sh | bash
   - export PATH="$HOME/.yarn/bin:$PATH"


### PR DESCRIPTION
Changements apportés dans cette pull request :

* Configuration du cache Travis pour yarn et le dossier `node_modules`
